### PR TITLE
Test: Use the FFMPEG module from the runtime

### DIFF
--- a/com.github.kalibari.audok.json
+++ b/com.github.kalibari.audok.json
@@ -17,30 +17,6 @@
     ],
     "modules": [
         {
-            "name": "ffmpeg",
-            "config-opts": [
-                "--enable-rpath",
-                "--enable-gpl",
-                "--disable-static",
-                "--enable-shared",
-                "--disable-doc",
-                "--disable-alsa",
-                "--disable-libx264",
-                "--disable-libx265",
-                "--enable-libmp3lame"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.ffmpeg.org/releases/ffmpeg-7.1.tar.gz",
-                    "sha512": "b0a82ca1a34fb9fa16ee4b7fa682d7c3fdcc68cd703c72487a2de434c714f2dede68d390e61dbb3669e435e271e4580d6bae00875d71a17ad39f43644c5fdd07"
-                }
-            ],
-            "cleanup": [
-                "/share/ffmpeg/examples"
-            ]
-        },
-        {
             "name": "streamripper",
             "no-autogen": true,
             "no-make-install": false,


### PR DESCRIPTION
Freedesktop runtime 25.08 (and related runtimes GNOME 49, KDE 6.10, and KDE 5.15-25.08) provides FFMPEG.

The build manifest of ffmpeg from the Freedesktop runtime version 25.08, which the related runtimes inherit, is here:

https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/freedesktop-sdk-25.08.6/elements/components/ffmpeg.bst#L22

Using it from runtime might reduce ffmpeg-related maintenance, but there might be some config differences related to the supported codecs.

Fixes: https://github.com/flathub/com.github.kalibari.audok/issues/87